### PR TITLE
Update LocalDevice.java

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -405,8 +405,8 @@ public class LocalDevice {
         if (timer != null) {
             timer.shutdown();
             try {
-                if (!timer.awaitTermination(10, TimeUnit.SECONDS))
-                    LOG.warn("BACnet4J timer did not shutdown within 10 seconds");
+                if (!timer.awaitTermination(400, TimeUnit.SECONDS))
+                    LOG.warn("BACnet4J timer did not shutdown within 400 seconds");
             } catch (final InterruptedException e) {
                 LOG.warn("Interrupted while waiting for shutdown of executors", e);
             }


### PR DESCRIPTION
Increased timeout duration to avoid an exception when there are a large number of BACnet objects.