### PR TITLE
RAD-4123 Allow null values for daily and exception schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BACnet4J
 
 BACnet4J is a pure Java implementation of the BACnet specification. Originally developed for supervisory use, it now includes support for many objects and so may be suitable for embedded use as well. Protocols supported include IPv4, IPv6, and MS/TP.  This library supports protocol Version 1 Revision 19.
 
-A discussion forum for this package can be found at http://infiniteautomation.com/forum/category/12/bacnet4j-general-discussion.
+A discussion forum for this package can be found at https://forum.mango-os.com/category/12/bacnet4j-general-discussion.
 
 **Commercial licenses are available by contacting: sales@radixiot.com**
 
@@ -57,7 +57,10 @@ The dependency information is BACnet4J pre 5.0 is:
 
 Releases
 ========
-*Version 6.0.0-SNAPSHOT*
+*Version 6.0.1*
+- Allow NULL values for daily and exception schedule
+
+*Version 6.0.0*
 - fix DeviceObjectTest.timeSynchronization test to pass
 - IAmRequest no longer automatically gets the extended device information this must now be done by adding an `IAmRequestListener` or using `DiscoveryUtils.getExtendedDeviceInformation(d1, rd);` The extended device info no longer retrieved is:
     * PropertyIdentifier.protocolServicesSupported

--- a/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
@@ -341,6 +341,11 @@ public class ScheduleObject extends BACnetObject {
                 }
 
                 // Determine the new present value.
+                // Our interpretation for ANSI/ASHRAE Standard 135-2016, 12.24.4 Present_Value
+                // When exception schedule with NULL values ignored then there is no possible way to deactivate schedules.
+                // Existing weekly schedule or another exception schedule with lower priority whose current value is not NULL will be used as present value.
+                // That makes allowing NULL values has no effect at all and functionally useless.
+                // This code should apply default schedule value to present value whenever effective schedule has NULL value.
                 if (currentTv == null || currentTv.getValue().getClass().equals(Null.class))
                     newValue = scheduleDefault;
                 else

--- a/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
@@ -74,6 +74,7 @@ import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Date;
+import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Primitive;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -187,7 +188,7 @@ public class ScheduleObject extends BACnetObject {
             final BACnetArray<DailySchedule> weeklySchedule = value.getValue();
             for (final DailySchedule daily : weeklySchedule) {
                 for (final TimeValue timeValue : daily.getDaySchedule()) {
-                    if (scheduleDefault.getClass() != timeValue.getValue().getClass()) {
+                    if (!timeValue.getValue().getClass().equals(Null.class) && scheduleDefault.getClass() != timeValue.getValue().getClass()) {
                         throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
                     }
                     if (!timeValue.getTime().isFullySpecified()) {
@@ -201,7 +202,7 @@ public class ScheduleObject extends BACnetObject {
             final SequenceOf<SpecialEvent> exceptionSchedule = value.getValue();
             for (final SpecialEvent specialEvent : exceptionSchedule) {
                 for (final TimeValue timeValue : specialEvent.getListOfTimeValues()) {
-                    if (scheduleDefault.getClass() != timeValue.getValue().getClass()) {
+                    if (!timeValue.getValue().getClass().equals(Null.class) && scheduleDefault.getClass() != timeValue.getValue().getClass()) {
                         throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
                     }
                     if (!timeValue.getTime().isFullySpecified()) {
@@ -340,7 +341,7 @@ public class ScheduleObject extends BACnetObject {
                 }
 
                 // Determine the new present value.
-                if (currentTv == null)
+                if (currentTv == null || currentTv.getValue().getClass().equals(Null.class))
                     newValue = scheduleDefault;
                 else
                     newValue = currentTv.getValue();

--- a/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
@@ -44,13 +44,17 @@ import com.serotonin.bacnet4j.type.notificationParameters.ChangeOfReliabilityNot
 import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Date;
+import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Primitive;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.RequestUtils;
 
 public class ScheduleObjectTest extends AbstractTest {
+    private final float defaultScheduledValue = 999;
+
     @Test
     public void fullTest() throws Exception {
         // Not really a full test. The effective period could be better.
@@ -76,7 +80,7 @@ public class ScheduleObjectTest extends AbstractTest {
                 new DailySchedule(new SequenceOf<>(new TimeValue(new Time(8, 0, 0, 0), new Real(10)),
                         new TimeValue(new Time(17, 0, 0, 0), new Real(11)))), //
                 new DailySchedule(new SequenceOf<>(new TimeValue(new Time(8, 0, 0, 0), new Real(12)),
-                        new TimeValue(new Time(17, 0, 0, 0), new Real(13)))), //
+                        new TimeValue(new Time(17, 0, 0, 0), new Null()))), //
                 new DailySchedule(new SequenceOf<>(new TimeValue(new Time(8, 0, 0, 0), new Real(14)),
                         new TimeValue(new Time(17, 0, 0, 0), new Real(15)))), //
                 new DailySchedule(new SequenceOf<>(new TimeValue(new Time(9, 0, 0, 0), new Real(16)),
@@ -96,7 +100,7 @@ public class ScheduleObjectTest extends AbstractTest {
                         new UnsignedInteger(7)), // Calendar
                 new SpecialEvent(new CalendarEntry(new Date(-1, null, 8, DayOfWeek.WEDNESDAY)),
                         new SequenceOf<>(new TimeValue(new Time(10, 30, 0, 0), new Real(24)),
-                                new TimeValue(new Time(17, 0, 0, 0), new Real(25))),
+                                new TimeValue(new Time(17, 0, 0, 0), new Null())),
                         new UnsignedInteger(6)) // 7th is a Wednesday
         );
         final SequenceOf<DeviceObjectPropertyReference> listOfObjectPropertyReferences = new SequenceOf<>( //
@@ -106,7 +110,7 @@ public class ScheduleObjectTest extends AbstractTest {
         );
 
         final ScheduleObject so = new ScheduleObject(d1, 0, "sch0", effectivePeriod, weeklySchedule, exceptionSchedule,
-                new Real(8), listOfObjectPropertyReferences, 12, false);
+                new Real(defaultScheduledValue), listOfObjectPropertyReferences, 12, false);
 
         Thread.sleep(100); // Let the requests be received.
         Assert.assertEquals(new Real(14), so.get(PropertyIdentifier.presentValue));
@@ -114,36 +118,38 @@ public class ScheduleObjectTest extends AbstractTest {
         Assert.assertEquals(new Real(14), av1.get(PropertyIdentifier.presentValue));
 
         // Start actual tests.
-        testTime(so, av0, av1, java.time.Month.MAY, 1, 17, 0, 15);
-        testTime(so, av0, av1, java.time.Month.MAY, 2, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 2, 9, 0, 16);
-        testTime(so, av0, av1, java.time.Month.MAY, 2, 20, 0, 17);
-        testTime(so, av0, av1, java.time.Month.MAY, 3, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 3, 13, 0, 22);
-        testTime(so, av0, av1, java.time.Month.MAY, 3, 14, 0, 23);
-        testTime(so, av0, av1, java.time.Month.MAY, 4, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 5, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 6, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 6, 8, 0, 10);
-        testTime(so, av0, av1, java.time.Month.MAY, 6, 17, 0, 11);
-        testTime(so, av0, av1, java.time.Month.MAY, 7, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 7, 8, 0, 12);
-        testTime(so, av0, av1, java.time.Month.MAY, 7, 17, 0, 13);
-        testTime(so, av0, av1, java.time.Month.MAY, 8, 0, 0, 8);
-        testTime(so, av0, av1, java.time.Month.MAY, 8, 10, 30, 24);
-        testTime(so, av0, av1, java.time.Month.MAY, 8, 17, 0, 25);
-        testTime(so, av0, av1, java.time.Month.MAY, 9, 0, 0, 8);
+        testTime(so, av0, av1, java.time.Month.MAY, 1, 17, 0, 15f);
+        testTime(so, av0, av1, java.time.Month.MAY, 2, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 2, 9, 0, 16f);
+        testTime(so, av0, av1, java.time.Month.MAY, 2, 20, 0, 17f);
+        testTime(so, av0, av1, java.time.Month.MAY, 3, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 3, 13, 0, 22f);
+        testTime(so, av0, av1, java.time.Month.MAY, 3, 14, 0, 23f);
+        testTime(so, av0, av1, java.time.Month.MAY, 4, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 5, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 6, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 6, 8, 0, 10f);
+        testTime(so, av0, av1, java.time.Month.MAY, 6, 17, 0, 11f);
+        testTime(so, av0, av1, java.time.Month.MAY, 7, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 7, 8, 0, 12f);
+        testTime(so, av0, av1, java.time.Month.MAY, 7, 17, 0, null); // Null schedule
+        testTime(so, av0, av1, java.time.Month.MAY, 8, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 8, 10, 30, 24f);
+        testTime(so, av0, av1, java.time.Month.MAY, 8, 17, 0, null);  // Null schedule
+        testTime(so, av0, av1, java.time.Month.MAY, 9, 0, 0, defaultScheduledValue);
     }
 
     private void testTime(final ScheduleObject so, final AnalogValueObject av0, final AnalogValueObject av1,
-            final java.time.Month month, final int day, final int hour, final int min, final float expectedValue)
+            final java.time.Month month, final int day, final int hour, final int min, final Float scheduledValue)
             throws Exception {
         clock.set(2115, month, day, hour, min, 0);
         so.updatePresentValue();
         Thread.sleep(100); // Let the requests be received.
-        Assert.assertEquals(new Real(expectedValue), so.get(PropertyIdentifier.presentValue));
-        Assert.assertEquals(new Real(expectedValue), av0.get(PropertyIdentifier.presentValue));
-        Assert.assertEquals(new Real(expectedValue), av1.get(PropertyIdentifier.presentValue));
+
+        Primitive expectedValue = scheduledValue == null ? new Real(defaultScheduledValue): new Real(scheduledValue);
+        Assert.assertEquals(expectedValue, so.get(PropertyIdentifier.presentValue));
+        Assert.assertEquals(expectedValue, av0.get(PropertyIdentifier.presentValue));
+        Assert.assertEquals(expectedValue, av1.get(PropertyIdentifier.presentValue));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
@@ -76,7 +76,12 @@ public class ScheduleObjectTest extends AbstractTest {
         final CalendarObject co = new CalendarObject(d1, 0, "cal0", dateList);
 
         final DateRange effectivePeriod = new DateRange(Date.UNSPECIFIED, Date.UNSPECIFIED);
-        final BACnetArray<DailySchedule> weeklySchedule = new BACnetArray<>( //
+
+        // Monday-Wednesday 8:00 and 17:00
+        // Thursday 9:00 and 20:00
+        // Friday 9:00 and 21:30
+        // Saturday-Sunday -
+        final BACnetArray<DailySchedule> weeklySchedule = new BACnetArray<>(
                 new DailySchedule(new SequenceOf<>(new TimeValue(new Time(8, 0, 0, 0), new Real(10)),
                         new TimeValue(new Time(17, 0, 0, 0), new Real(11)))), //
                 new DailySchedule(new SequenceOf<>(new TimeValue(new Time(8, 0, 0, 0), new Real(12)),
@@ -89,7 +94,11 @@ public class ScheduleObjectTest extends AbstractTest {
                         new TimeValue(new Time(21, 30, 0, 0), new Real(19)))), //
                 new DailySchedule(new SequenceOf<TimeValue>()), //
                 new DailySchedule(new SequenceOf<TimeValue>()));
-        final SequenceOf<SpecialEvent> exceptionSchedule = new SequenceOf<>( //
+
+        // Every Friday, November to February, The Wednesday during the 4th week of each month - 8:00 and 22:00 (Priority:10)
+        // Every Friday, November to February, The Wednesday during the 4th week of each month - 13:00 and 14:00 (Priority:7)
+        // 7.th Wednesday 10:30 and 17:00 (Priority:6)
+        final SequenceOf<SpecialEvent> exceptionSchedule = new SequenceOf<>(
                 new SpecialEvent(co.getId(),
                         new SequenceOf<>(new TimeValue(new Time(8, 0, 0, 0), new Real(20)),
                                 new TimeValue(new Time(22, 0, 0, 0), new Real(21))),
@@ -118,25 +127,25 @@ public class ScheduleObjectTest extends AbstractTest {
         Assert.assertEquals(new Real(14), av1.get(PropertyIdentifier.presentValue));
 
         // Start actual tests.
-        testTime(so, av0, av1, java.time.Month.MAY, 1, 17, 0, 15f);
-        testTime(so, av0, av1, java.time.Month.MAY, 2, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 2, 9, 0, 16f);
-        testTime(so, av0, av1, java.time.Month.MAY, 2, 20, 0, 17f);
-        testTime(so, av0, av1, java.time.Month.MAY, 3, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 3, 13, 0, 22f);
-        testTime(so, av0, av1, java.time.Month.MAY, 3, 14, 0, 23f);
-        testTime(so, av0, av1, java.time.Month.MAY, 4, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 5, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 6, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 6, 8, 0, 10f);
-        testTime(so, av0, av1, java.time.Month.MAY, 6, 17, 0, 11f);
-        testTime(so, av0, av1, java.time.Month.MAY, 7, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 7, 8, 0, 12f);
-        testTime(so, av0, av1, java.time.Month.MAY, 7, 17, 0, null); // Null schedule
-        testTime(so, av0, av1, java.time.Month.MAY, 8, 0, 0, defaultScheduledValue);
-        testTime(so, av0, av1, java.time.Month.MAY, 8, 10, 30, 24f);
-        testTime(so, av0, av1, java.time.Month.MAY, 8, 17, 0, null);  // Null schedule
-        testTime(so, av0, av1, java.time.Month.MAY, 9, 0, 0, defaultScheduledValue);
+        testTime(so, av0, av1, java.time.Month.MAY, 1, 17, 0, 15f); // Wednesday
+        testTime(so, av0, av1, java.time.Month.MAY, 2, 0, 0, defaultScheduledValue); // Thursday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 2, 9, 0, 16f); // Thursday
+        testTime(so, av0, av1, java.time.Month.MAY, 2, 20, 0, 17f); // Thursday
+        testTime(so, av0, av1, java.time.Month.MAY, 3, 0, 0, defaultScheduledValue); // Friday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 3, 13, 0, 22f); // Exception schedule at 13:00 with priority 7
+        testTime(so, av0, av1, java.time.Month.MAY, 3, 14, 0, 23f); // Exception schedule at 14:00 with priority 7
+        testTime(so, av0, av1, java.time.Month.MAY, 4, 0, 0, defaultScheduledValue); // Saturday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 5, 0, 0, defaultScheduledValue); // Sunday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 6, 0, 0, defaultScheduledValue); // Monday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 6, 8, 0, 10f); // Monday
+        testTime(so, av0, av1, java.time.Month.MAY, 6, 17, 0, 11f);  // Monday
+        testTime(so, av0, av1, java.time.Month.MAY, 7, 0, 0, defaultScheduledValue); // Tuesday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 7, 8, 0, 12f); // Tuesday
+        testTime(so, av0, av1, java.time.Month.MAY, 7, 17, 0, null); // Null schedule from weekly schedule
+        testTime(so, av0, av1, java.time.Month.MAY, 8, 0, 0, defaultScheduledValue); // Wednesday beginning of the day
+        testTime(so, av0, av1, java.time.Month.MAY, 8, 10, 30, 24f); // Exception schedule at 10:30 with priority 6
+        testTime(so, av0, av1, java.time.Month.MAY, 8, 17, 0, null);  // Null schedule from exception schedule
+        testTime(so, av0, av1, java.time.Month.MAY, 9, 0, 0, defaultScheduledValue); // Thursday beginning of the day
     }
 
     private void testTime(final ScheduleObject so, final AnalogValueObject av0, final AnalogValueObject av1,


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/RAD-4123

NULL shall be allowed to configure in the value (time-value) of Daily Schedule and Exception Schedule

> ANSI/ASHRAE Standard 135-2016 Page: 293
>
> The normal calculation of the value of the Present_Value property is illustrated as follows (the actual algorithm used is a local matter but shall yield the same results as this one):
> 1. Find the highest relative priority (as defined by Clause 12.24.8) Exception_Schedule array element that is in effect for the current day and whose current value (see method below) is not NULL, and assign that value to the Present_Value property.
> 2. If the Present_Value was not assigned in the previous step, then evaluate the current value of the Weekly_Schedule array element for the current day and if that value is not NULL, assign it to the Present_Value property.
> 3. If the Present_Value was not assigned in the previous steps, then assign the value of the Schedule_Default property to the Present_Value property.