### PR TITLE
Add option to update the remote device cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Releases
 - Allow NULL values for daily schedule, exception schedule and schedule default
 - Fix scheduling issues when TimeValue sequences are not in chronological order
 - Fix schedule object using incorrect time format to trigger next update
+- Add new CacheUpdate option to the startRemoteDeviceDiscovery() method of LocalDevice 
 
 *Version 6.0.0*
 - fix DeviceObjectTest.timeSynchronization test to pass

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,32 @@
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.8.2</version>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.6.0</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+					<outputDirectory>${project.build.directory}</outputDirectory>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -850,8 +850,17 @@ public class LocalDevice implements AutoCloseable {
     }
 
     public enum CacheUpdate {
+        /**
+         * Always update the remote device cache, even if the existing entry has not expired.
+         */
         ALWAYS,
+        /**
+         * Never update the remote device cache, even if the existing entry has expired.
+         */
         NEVER,
+        /**
+         * Only update the remote device cache if the existing entry has expired.
+         */
         IF_EXPIRED
     }
 
@@ -867,8 +876,8 @@ public class LocalDevice implements AutoCloseable {
      * Creates and starts a remote device discovery. Discovered devices are added to the cache as they are found. The
      * returned discoverer must be stopped by the caller.
      *
-     * @param callback
-     *            optional client callback
+     * @param cacheUpdate controls if the remote device cache should be updated
+     * @param callback optional client callback
      * @return the discoverer, which must be stopped by the caller
      */
     public RemoteDeviceDiscoverer startRemoteDeviceDiscovery(CacheUpdate cacheUpdate, final Consumer<RemoteDevice> callback) {

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -108,7 +108,7 @@ import lohbihler.warp.WarpUtils;
  * - default character string encoding
  * - persistence of recipient lists in notification forwarder object
  */
-public class LocalDevice {
+public class LocalDevice implements AutoCloseable {
     static final Logger LOG = LoggerFactory.getLogger(LocalDevice.class);
     public static final String VERSION = "6.0.0";
 
@@ -840,6 +840,13 @@ public class LocalDevice {
         }
 
         return rd;
+    }
+
+    @Override
+    public synchronized void close() throws Exception {
+        if (initialized) {
+            terminate();
+        }
     }
 
     public enum CacheUpdate {

--- a/src/test/java/com/serotonin/bacnet4j/LocalDeviceTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/LocalDeviceTest.java
@@ -9,7 +9,12 @@ import static org.junit.Assert.fail;
 
 import java.time.Clock;
 import java.util.Collection;
-import java.util.concurrent.*;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import com.serotonin.bacnet4j.LocalDevice.CacheUpdate;
 import com.serotonin.bacnet4j.cache.CachePolicies;

--- a/src/test/java/com/serotonin/bacnet4j/util/RemoteDeviceDiscovererTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/RemoteDeviceDiscovererTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 
@@ -164,7 +163,7 @@ public class RemoteDeviceDiscovererTest {
 
     @Test
     public void expirationCheck() throws Exception {
-        BlockingQueue<RemoteDevice> results = new ArrayBlockingQueue<>(10);
+        BlockingQueue<RemoteDevice> results = new ArrayBlockingQueue<>(1);
 
         try (LocalDevice d1 = createLocalDevice(1);
              LocalDevice d2 = createLocalDevice(2)) {
@@ -172,8 +171,7 @@ public class RemoteDeviceDiscovererTest {
             d1.initialize();
             d2.initialize();
 
-            RemoteDeviceDiscoverer discoverer = new RemoteDeviceDiscoverer(d1, results::add, d -> true);
-            try {
+            try (RemoteDeviceDiscoverer discoverer = new RemoteDeviceDiscoverer(d1, results::add, d -> true)) {
                 discoverer.start();
 
                 RemoteDevice firstResponse = results.poll(10, TimeUnit.SECONDS);
@@ -184,8 +182,6 @@ public class RemoteDeviceDiscovererTest {
                 RemoteDevice secondResponse = results.poll(10, TimeUnit.SECONDS);
                 Assert.assertNotNull(secondResponse);
                 Assert.assertEquals(2, secondResponse.getInstanceNumber());
-            } finally {
-                discoverer.stop();
             }
         }
 


### PR DESCRIPTION
- Adds new `CacheUpdate` option to the `startRemoteDeviceDiscovery()` methods on `LocalDevice`
  - Default is `NEVER` which matches the existing functionality - the cache is never updated
  - `ALWAYS` means that the the cache will always be updated even if the existing device in the cache has not expired
  - `IF_EXPIRED` means that the the cache will only be updated if the existing device in the cache has expired
- Adds tests covering new functionality
- Make `LocalDevice` and `RemoteDeviceDiscoverer` implement `AutoClosable`